### PR TITLE
[fix] correct buffer size after fread

### DIFF
--- a/src/maindx.cpp
+++ b/src/maindx.cpp
@@ -655,6 +655,8 @@ HRESULT createShader(const std::string &file, ID3D11PixelShader** ppPShader)
     source.resize(ftell(f));
     fseek(f, 0, SEEK_SET);
     size_t read = fread(&source[0], 1, source.size(), f);
+    // CRLF is replaced with LF by fread
+    source.resize(read);
     fclose(f);
 
     std::ostringstream ss;


### PR DESCRIPTION
fread replaces CRLF with LF on the fly.
Because of that the buffer might be too big and contains one or more null char(s) at the end.

fixes #33